### PR TITLE
fix: only test go 1

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         # List of go versions to test on.
-        go: ['^1.16', '^1.17', '^1']
+        go: ['^1']
     steps:
       # Checkout go code to test.
       - name: Checkout repo

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         # List of go versions to test on.
-        go: ['^1.16', '^1.17', '^1']
+        go: ['^1']
     steps:
       # Checkout go code to test.
       - name: Checkout repo


### PR DESCRIPTION
We use go1.18 features pretty commonly now, so older versions than
are not needed. Also, the older versions were tetsing using go 1.18
anyways since it technically fulfilled their regex I guess...
So this will save use on processing minutes for no change.