### PR TITLE
Update all actions to versions that use Node 16

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -125,7 +125,7 @@ jobs:
       # Setup docker build arguments.
       - name: Docker release meta
         id: release
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ github.repository }}
@@ -134,10 +134,10 @@ jobs:
       # Setup Docker builder to do build.
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       # Build the app.
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false
           context: .

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the commits to lint.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # setup node, needed to lint commits.
@@ -47,10 +47,10 @@ jobs:
     steps:
       # Checkout code to build.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Go in order to vendor dependencies in a later step.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1'
       # Use auth to get access to private Git repos for Go code dependencies.
@@ -60,7 +60,7 @@ jobs:
           GITHUB_USERNAME: kochava-ci
         run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
 
@@ -76,10 +76,10 @@ jobs:
     steps:
       # Checkout go code to test.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Go for each version in the matrix.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       # Use auth to get access to private Git repos for Go code dependencies.
@@ -107,10 +107,10 @@ jobs:
     steps:
       # Checkout code to build.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Go in order to vendor dependencies in a later step.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1'
       # Use auth to get access to private Git repos for Go code dependencies.

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout code to release.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Node needed to create release.
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout code needed to build docker image.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Setup Go in order to vendor dependencies in a later setp.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1'
       # Use auth to get access to private Git repos for Go code dependencies.

--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -82,7 +82,7 @@ jobs:
       # Create docker image meta data. Docker tags include the Git tag itself and the sematic version parsing of that tag if possible.
       - name: Docker release meta
         id: release
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ env.ARTIFACT_REGISTRY_IMAGE_NAME }}
@@ -97,7 +97,7 @@ jobs:
         env:
           ARTIFACT_REGISTRY_JSON_KEY: ${{ secrets.ARTIFACT_REGISTRY_JSON_KEY }}
         if: ${{ env.ARTIFACT_REGISTRY_JSON_KEY }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ secrets.ARTIFACT_REGISTRY }}
           username: _json_key
@@ -107,21 +107,21 @@ jobs:
         env:
           CONTAINER_REGISTRY_JSON_KEY: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
         if: ${{ env.CONTAINER_REGISTRY_JSON_KEY }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ secrets.CONTAINER_REGISTRY }}
           username: _json_key
           password: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
       # Setup QEMU needed to build arm64 images.
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       # Setup Docker builder needed to build multi-architectural images.
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       # Build and push the image.
       - name: Build and Push to Artifact Registry and Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           context: .

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the commits to lint.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # setup node, needed to lint commits.
@@ -47,10 +47,10 @@ jobs:
     steps:
       # Checkout code to build.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Go in order to vendor dependencies in a later step.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1'
       # Use auth to get access to private Git repos for Go code dependencies.
@@ -60,7 +60,7 @@ jobs:
           GITHUB_USERNAME: kochava-ci
         run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
 
@@ -76,10 +76,10 @@ jobs:
     steps:
       # Checkout go code to test.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Go for each version in the matrix.
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       # Use auth to get access to private Git repos for Go code dependencies.

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout code to release.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Node needed to create release.
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/php_lib_pull_requests.yml
+++ b/.github/workflows/php_lib_pull_requests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the commits to lint.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # setup node, needed to lint commits.
@@ -56,7 +56,7 @@ jobs:
     steps:
       # Checkout php code to test.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Setup PHP for each version in the matrix.
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action

--- a/.github/workflows/php_lib_push_main.yml
+++ b/.github/workflows/php_lib_push_main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout code to release.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Node needed to create release.
       - name: Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
PR to test in Kochava/mrklean-api (lint timed out and passed after re-run): Kochava/mrklean-api#61
Release test, creating a pre-release tag from the branch in the above PR: https://github.com/Kochava/mrklean-api/actions/runs/3441558160