### PR TITLE
Update repo name parsing to use new output method

### DIFF
--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Parse Repo Name
         id: parse_repo_name
         run: |
-          echo ::set-output name=repo_name::"$( echo '${{ github.repository }}' | awk -F '/' '{print $2}' )"
+          echo "repo_name=$( echo '${{ github.repository }}' | awk -F '/' '{print $2}' )" >> $GITHUB_OUTPUT
       # Make the docker fields for Artifact Registry if we're pushing to it.
       - name: Construct Artifact Registry fields
         env:


### PR DESCRIPTION
Remove use of deprecated set-output command.

Test release run: https://github.com/Kochava/mrklean-kleaners/actions/runs/3448362748/jobs/5755318564 (See the release [here](https://github.com/Kochava/mrklean-kleaners/releases/tag/v1.5.3-rc01-ci-test))

Image in GCR: https://console.cloud.google.com/gcr/images/gleaming-medium-99216/global/mrklean-kleaners