### PR TITLE
fix: back to v3 and provenance false

### DIFF
--- a/.github/workflows/base_app_release.yml
+++ b/.github/workflows/base_app_release.yml
@@ -101,9 +101,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
       # Build and push the image.
       - name: Build and Push to Artifact Registry and Container Registry
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v3
         with:
           push: true
+          provenance: false
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -137,9 +137,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
       # Build the app.
       - name: Build
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v3
         with:
           push: false
+          provenance: false
           context: .
           file: Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -121,9 +121,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
       # Build and push the image.
       - name: Build and Push to Artifact Registry and Container Registry
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v3
         with:
           push: true
+          provenance: false
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
First PR didn't quite do the job, turns out the `buildx` version would also need to get pinned `< v0.10` so instead i'm opting for only changing one thing.