### PR TITLE
fix: pin semantic release version

### DIFF
--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -36,4 +36,4 @@ jobs:
           GIT_AUTHOR_EMAIL: release@test.com
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
-        run: npx semantic-release
+        run: npx semantic-release@22.0.8


### PR DESCRIPTION
I'm getting a GitHub Actions error here and in other repos as well and am going to see if pinning the semantic release version to the previous version will work: 

https://github.com/Kochava/sprinkler-api/actions/runs/7105032197