### PR TITLE
fix(commitlint): pin commitlint config at v18.6.0

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 18
       # Install needed libraries to lint commits.
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       # Lint the commits.
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
   lint:

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 18
       # Install needed libraries to lint commits.
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       # Lint the commits.
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
   lint:

--- a/.github/workflows/gradle_app_pull_request.yml
+++ b/.github/workflows/gradle_app_pull_request.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 18
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
   lint:
     #

--- a/.github/workflows/gradle_jvm_app_pull_requests.yml
+++ b/.github/workflows/gradle_jvm_app_pull_requests.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 18
       # Install needed libraries to lint commits.
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       # Lint the commits.
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
   docker-build:

--- a/.github/workflows/php_lib_pull_requests.yml
+++ b/.github/workflows/php_lib_pull_requests.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: 18
       # Install needed libraries to lint commits.
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       # Lint the commits.
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/ruby_app_pull_requests.yml
+++ b/.github/workflows/ruby_app_pull_requests.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 18
       # Install needed libraries to lint commits.
-      - run: npm install --save-dev @commitlint/{config-conventional,cli}
+      - run: npm install --save-dev @commitlint/{config-conventional@v18.6.0,cli}
       # Lint the commits.
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
 


### PR DESCRIPTION
v18.6.1 in commitlint/config-conventional broke our actions since we use a yaml file for the config rather than a 
Javascript or Typescript file. Pinning that package at v18.6.0 fixes the issue, per 
[this issue](https://github.com/conventional-changelog/commitlint/issues/3909).
