### PR TITLE
fix: adding option to not use composer options

### DIFF
--- a/.github/workflows/php_lib_pull_requests.yml
+++ b/.github/workflows/php_lib_pull_requests.yml
@@ -19,11 +19,11 @@ on:
         required: false
         default: "."
         type: string
-      USE_COMPOSER_OPTIONS:
-        description: 'whether to use the composer options or not'
+      COMPOSER_OPTIONS:
+        description: 'composer options to use'
         required: false
-        default: true
-        type: boolean
+        default: "--ignore-platform-reqs"
+        type: string
     secrets:
       COMPOSER_AUTH:
         description: 'Auth JSON for Composer'
@@ -68,21 +68,13 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
       # Vendor PHP code.
-      - name: Composer With Options
-        if: ${{ inputs.USE_COMPOSER_OPTIONS }}
+      - name: Composer
         env:
           COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH }}'
         uses: "ramsey/composer-install@v2"
         with:
           working-directory: "${{ inputs.COMPOSER_WORKING_DIRECTORY }}"
-          composer-options: "--ignore-platform-reqs"
-      - name: Composer Without Options
-        if: ${{ !inputs.USE_COMPOSER_OPTIONS }}
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH }}'
-        uses: "ramsey/composer-install@v2"
-        with:
-          working-directory: "${{ inputs.COMPOSER_WORKING_DIRECTORY }}"
+          composer-options: "${{ inputs.COMPOSER_OPTIONS }}"
       # Run PHP linter.
       - name: php lint
         if: ${{ inputs.PHP_LINT }}

--- a/.github/workflows/php_lib_pull_requests.yml
+++ b/.github/workflows/php_lib_pull_requests.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: "."
         type: string
+      USE_COMPOSER_OPTIONS:
+        description: 'whether to use the composer options or not'
+        required: false
+        default: true
+        type: boolean
     secrets:
       COMPOSER_AUTH:
         description: 'Auth JSON for Composer'
@@ -63,13 +68,21 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
       # Vendor PHP code.
-      - name: Composer
+      - name: Composer With Options
+        if: ${{ inputs.USE_COMPOSER_OPTIONS }}
         env:
           COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH }}'
         uses: "ramsey/composer-install@v2"
         with:
           working-directory: "${{ inputs.COMPOSER_WORKING_DIRECTORY }}"
           composer-options: "--ignore-platform-reqs"
+      - name: Composer Without Options
+        if: ${{ !inputs.USE_COMPOSER_OPTIONS }}
+        env:
+          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH }}'
+        uses: "ramsey/composer-install@v2"
+        with:
+          working-directory: "${{ inputs.COMPOSER_WORKING_DIRECTORY }}"
       # Run PHP linter.
       - name: php lint
         if: ${{ inputs.PHP_LINT }}


### PR DESCRIPTION
Adding the option to not use the composer-options in the test job for the php pull request workflow