### PR TITLE
fix: pin golangci-lint version and enable only-new-issues for PRs

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -80,9 +80,11 @@ jobs:
     #
     runs-on: ubuntu-latest
     steps:
-      # Checkout code to build.
+      # Checkout code to build (fetch-depth: 0 needed for only-new-issues diff).
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       # Setup Go.
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -98,7 +100,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.1.6
+          only-new-issues: true
           args: --timeout=5m --enable=bodyclose
   test:
     #


### PR DESCRIPTION
## Problem

The `lint` job in `go_app_pull_requests.yml` takes **~5.5 minutes** on repos with large dependency trees (e.g., `Kochava/mcp` with 143 deps). golangci-lint must compile the entire dependency tree for static analysis on every PR run, even when only a handful of files changed.

Additionally, `version: latest` is used, which the [golangci-lint-action README explicitly warns against](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use):

> We recommend using a fixed version to guarantee reproducibility.

Using `latest` means a new golangci-lint release can break CI across all repos without any code changes, and invalidates the action's cache on every release.

## Changes

Three targeted changes to the `lint` job only:

1. **Pin `version: v2.1.6`** instead of `latest` — guarantees reproducible builds and stable cache hits
2. **Add `only-new-issues: true`** — PRs only flag lint issues *introduced by the PR*, not pre-existing debt. This is the [recommended configuration for PR checks](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues) per the official docs.
3. **Add `fetch-depth: 0`** to the checkout step — required for `only-new-issues` to diff against the base branch

## Impact

- Applies to all repos using this shared workflow (~141 repos)
- PRs will get faster lint feedback (seconds instead of minutes for large repos)
- Pre-existing lint issues will no longer block unrelated PRs (clean them up via dedicated lint-fix PRs instead)
- No changes to test, docker-build, commitlint, or any other jobs

## References

- [golangci-lint-action README — `only-new-issues`](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues)
- [golangci-lint-action README — version pinning](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)