### PR TITLE
fix: revert golangci-lint pin to latest (Go 1.26 compat)

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: latest
           only-new-issues: true
           args: --timeout=5m --enable=bodyclose
   test:


### PR DESCRIPTION
## Problem

PR #68 pinned golangci-lint to `v2.1.6`, but that version was built with Go 1.24. Since this workflow uses `go-version: 'stable'` (currently Go 1.26.2), golangci-lint panics on every run:

```
panic: file requires newer Go version go1.26 (application built with go1.24)
```

This is breaking lint on all repos — e.g., [Kochava/mcp#229](https://github.com/Kochava/mcp/pull/229).

## Root cause

Pinning golangci-lint is incompatible with a floating Go version (`stable`). When Go bumps, the pinned linter falls behind and crashes. We'd have to update the pin every time Go releases a new version.

## Fix

Revert `version` back to `latest` while keeping `only-new-issues: true` from #68. This is a reasonable tradeoff because:

- `latest` ensures the linter is always compatible with whatever `go-version: stable` resolves to
- `only-new-issues: true` mitigates the main risk of `latest` — new lint rules only surface on changed code in PRs, not the entire codebase (per [golangci-lint-action docs](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues))
- `fetch-depth: 0` from #68 is already in place for the diff to work

## After merge

The `go/app/v1` tag needs to be moved to the new main HEAD for this to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)