### PR TITLE
fix: increase golangci-lint timeout from 5m to 10m

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
-          args: --timeout=5m --enable=bodyclose
+          args: --timeout=10m --enable=bodyclose
   test:
     #
     # ensure go standards and tests pass


### PR DESCRIPTION
## Problem

Repos with large dependency trees (e.g., `Kochava/mcp` with 143 deps) need ~6 minutes for golangci-lint to compile and analyze on CI runners. The current `--timeout=5m` causes the linter to exit with code 4 (timeout) even when there are 0 lint issues:

```
0 issues.
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
Error: golangci-lint exit with code 4
Ran golangci-lint in 369884ms
```

## Fix

Bump `--timeout=5m` to `--timeout=10m`. This is a safe change — repos that finish quickly are unaffected (the timeout is just a ceiling, not a delay). Only repos with large dependency trees benefit.

## Context

This is the final piece after #68 (`only-new-issues`, `fetch-depth: 0`) and #69 (revert version pin). Those changes are working correctly — the linter now reports only new issues and uses a Go-compatible version. This just gives it enough time to finish the analysis.

After merge, `go/app/v1` tag needs to be moved to the new main HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)