### PR TITLE
Feat/extra junit reports

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -176,14 +176,16 @@ jobs:
           name: junit-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Integration tests (conditional, per-module)
-      # INTEGRATION_COVERAGE=true enables runtime coverage collection for services
-      # that run in Docker containers (e.g., testcontainers-based tests)
+      # Coverage is collected from two sources:
+      # 1. Go integration tests running in-process (via -cover and -test.gocoverdir)
+      # 2. Services running in Docker containers (via INTEGRATION_COVERAGE=true env var)
       - name: integration tests
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          INTEGRATION_COVERAGE=true go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
-            | tee integration_test_output.txt
+          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+            -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
+            2>&1 | tee integration_test_output.txt
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -207,10 +207,27 @@ jobs:
       - name: build coverage.txt
         working-directory: ${{ matrix.module }}
         run: |
-          if [ -d coverage/int ] && [ "$(ls -A coverage/int)" ]; then
-            go tool covdata textfmt -i=./coverage/int,./coverage/unit -o coverage.txt
-          else
+          HAS_UNIT=false
+          HAS_INT=false
+          if [ -d coverage/unit ] && [ "$(ls -A coverage/unit 2>/dev/null)" ]; then
+            HAS_UNIT=true
+          fi
+          if [ -d coverage/int ] && [ "$(ls -A coverage/int 2>/dev/null)" ]; then
+            HAS_INT=true
+          fi
+
+          if [ "$HAS_UNIT" = true ] && [ "$HAS_INT" = true ]; then
+            echo "Combining unit and integration coverage"
+            go tool covdata textfmt -i=./coverage/unit,./coverage/int -o coverage.txt
+          elif [ "$HAS_UNIT" = true ]; then
+            echo "Using unit coverage only"
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
+          elif [ "$HAS_INT" = true ]; then
+            echo "Using integration coverage only"
+            go tool covdata textfmt -i=./coverage/int -o coverage.txt
+          else
+            echo "No coverage data found"
+            echo "mode: set" > coverage.txt
           fi
       - name: Upload test coverage results to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -176,11 +176,13 @@ jobs:
           name: junit-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Integration tests (conditional, per-module)
+      # INTEGRATION_COVERAGE=true enables runtime coverage collection for services
+      # that run in Docker containers (e.g., testcontainers-based tests)
       - name: integration tests
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+          INTEGRATION_COVERAGE=true go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             | tee integration_test_output.txt
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -151,11 +151,11 @@ jobs:
         run: |
           mkdir -p ${{ matrix.module }}/coverage/unit
           mkdir -p ${{ matrix.module }}/coverage/int
-      # Run unit tests for the module.
+      # Run unit tests with race detector and coverage
       - name: go test
         working-directory: ${{ matrix.module }}
         run: |
-          go test -cover --race -v ${{ inputs.GO_TEST_UNIT_TAGS }} ./... \
+          go test -cover -race -v ${{ inputs.GO_TEST_UNIT_TAGS }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/unit" \
             2>&1 | tee unit_test_output.txt
       - name: Build Unit Test Junit report
@@ -205,39 +205,45 @@ jobs:
           files: ${{ matrix.module }}/junit_integration_report.xml
           name: junit-integration-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
-      # Coverage handling
-      - name: build coverage.txt
+      # Coverage handling - upload unit and integration separately
+      # (they use different coverage modes: atomic vs set, so can't be combined locally)
+      # Codecov will merge them automatically
+      - name: build unit coverage
         working-directory: ${{ matrix.module }}
         run: |
-          HAS_UNIT=false
-          HAS_INT=false
           if [ -d coverage/unit ] && [ "$(ls -A coverage/unit 2>/dev/null)" ]; then
-            HAS_UNIT=true
-          fi
-          if [ -d coverage/int ] && [ "$(ls -A coverage/int 2>/dev/null)" ]; then
-            HAS_INT=true
-          fi
-
-          if [ "$HAS_UNIT" = true ] && [ "$HAS_INT" = true ]; then
-            echo "Combining unit and integration coverage"
-            go tool covdata textfmt -i=./coverage/unit,./coverage/int -o coverage.txt
-          elif [ "$HAS_UNIT" = true ]; then
-            echo "Using unit coverage only"
-            go tool covdata textfmt -i=./coverage/unit -o coverage.txt
-          elif [ "$HAS_INT" = true ]; then
-            echo "Using integration coverage only"
-            go tool covdata textfmt -i=./coverage/int -o coverage.txt
+            echo "Converting unit coverage to text format"
+            go tool covdata textfmt -i=./coverage/unit -o coverage-unit.txt
           else
-            echo "No coverage data found"
-            echo "mode: set" > coverage.txt
+            echo "No unit coverage data found"
           fi
-      - name: Upload test coverage results to Codecov
+      - name: build integration coverage
+        working-directory: ${{ matrix.module }}
+        run: |
+          if [ -d coverage/int ] && [ "$(ls -A coverage/int 2>/dev/null)" ]; then
+            echo "Converting integration coverage to text format"
+            go tool covdata textfmt -i=./coverage/int -o coverage-int.txt
+          else
+            echo "No integration coverage data found"
+          fi
+      - name: Upload unit test coverage to Codecov
+        if: ${{ hashFiles(format('{0}/coverage-unit.txt', matrix.module)) != '' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ matrix.module }}/coverage.txt
+          files: ${{ matrix.module }}/coverage-unit.txt
+          flags: unit
           verbose: true
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false
+      - name: Upload integration test coverage to Codecov
+        if: ${{ hashFiles(format('{0}/coverage-int.txt', matrix.module)) != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.module }}/coverage-int.txt
+          flags: integration
+          verbose: true
+          fail_ci_if_error: false
   docker-build:
     #
     # ensures the docker image will build without pushing to the registry

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -202,6 +202,7 @@ jobs:
           name: Integration Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/junit_integration_report.xml
           reporter: java-junit
+          fail-on-error: 'false'
       - name: Upload integration test results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/test-results-action@v1

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -194,7 +194,9 @@ jobs:
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
-        run: go-junit-report -in integration_test_output.txt -set-exit-code > junit_integration_report.xml || true
+        run: |
+          grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
+          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml || true
       - name: Integration Test Report
         uses: dorny/test-reporter@v1
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           mkdir -p ${{ matrix.module }}/coverage/unit
           mkdir -p ${{ matrix.module }}/coverage/int
+          mkdir -p ${{ matrix.module }}/coverage/e2e
       # Run unit tests with race detector and coverage
       - name: go test
         working-directory: ${{ matrix.module }}
@@ -266,6 +267,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage-int.txt
           flags: integration
+          verbose: true
+          fail_ci_if_error: false
+      - name: build e2e coverage
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        working-directory: ${{ matrix.module }}
+        run: |
+          if [ -d coverage/e2e ] && [ "$(ls -A coverage/e2e 2>/dev/null)" ]; then
+            echo "Converting e2e coverage to text format"
+            go tool covdata textfmt -i=./coverage/e2e -o coverage-e2e.txt
+          else
+            echo "No e2e coverage data found"
+          fi
+      - name: Upload e2e test coverage to Codecov
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.module }}/coverage-e2e.txt
+          flags: e2e
           verbose: true
           fail_ci_if_error: false
   docker-build:

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -220,15 +220,20 @@ jobs:
           name: junit-integration-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
-      - name: Extra Test Report
+      - name: Check extra JUnit report exists
+        id: check_extra_report
         if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        run: test -f "${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}"
+        continue-on-error: true
+      - name: Extra Test Report
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
-            2>&1 | tee integration_test_output.txt
+            > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
@@ -212,14 +212,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
       - name: Extra Test Report
-        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/test-results-action@v1
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -192,26 +192,28 @@ jobs:
       - name: integration tests
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
+        shell: bash
         run: |
+          set -o pipefail
           INTEGRATION_COVERAGE=true go test -cover -covermode=atomic -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
             > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report
-        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
           grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
-          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml || true
+          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml
       - name: Integration Test Report
         uses: dorny/test-reporter@v1
-        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.GO_TEST_INTEGRATION_ENABLED }}
         with:
           name: Integration Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/junit_integration_report.xml
           reporter: java-junit
           fail-on-error: 'false'
       - name: Upload integration test results to Codecov
-        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -193,7 +193,7 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+          INTEGRATION_COVERAGE=true go test -cover -covermode=atomic -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
             > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -26,6 +26,11 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      EXTRA_JUNIT_REPORT:
+        description: "Path to an additional JUnit XML report (e.g., from Python integration tests). Relative to the module directory."
+        type: string
+        required: false
+        default: ""
     secrets:
       GH_CI_PAT:
         description: 'Token password for GitHub auth'
@@ -204,6 +209,22 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
           files: ${{ matrix.module }}/junit_integration_report.xml
           name: junit-integration-report-${{ strategy.job-index }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # Extra JUnit report (e.g., from Python integration tests running inside Docker)
+      - name: Extra Test Report
+        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: dorny/test-reporter@v1
+        with:
+          name: Extra Test Report (${{ matrix.module }})
+          path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          reporter: java-junit
+      - name: Upload extra test results to Codecov
+        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: codecov/test-results-action@v1
+        with:
+          fail_ci_if_error: false
+          files: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          name: junit-extra-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Coverage handling - upload unit and integration separately
       # (they use different coverage modes: atomic vs set, so can't be combined locally)

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -202,7 +202,7 @@ jobs:
         if: ${{ (success() || failure()) && inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
+          grep -E '^(\s*=== |\s*--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
           go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml
       - name: Integration Test Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -178,7 +178,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -214,7 +214,7 @@ jobs:
           fail-on-error: 'false'
       - name: Upload integration test results to Codecov
         if: ${{ (success() || failure()) && inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -236,7 +236,7 @@ jobs:
           reporter: java-junit
       - name: Upload extra test results to Codecov
         if: ${{ steps.check_extra_report.outcome == 'success' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
           report_type: test_results
@@ -253,7 +253,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -272,7 +272,7 @@ jobs:
           fi
       - name: Upload e2e test coverage to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -280,18 +280,6 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
-      - name: Create Codecov commit
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: create-commit
-      - name: Send Codecov notifications
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: send-notifications
   docker-build:
     #
     # ensures the docker image will build without pushing to the registry

--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -280,6 +280,18 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
+      - name: Create Codecov commit
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: create-commit
+      - name: Send Codecov notifications
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications
   docker-build:
     #
     # ensures the docker image will build without pushing to the registry

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -141,8 +141,9 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
-            | tee integration_test_output.txt
+          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+            -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
+            > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
@@ -164,14 +165,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
       - name: Extra Test Report
-        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/test-results-action@v1
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -154,6 +154,7 @@ jobs:
         with:
           name: Integration Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/junit_integration_report.xml
+          fail-on-error: 'false'
           reporter: java-junit
       - name: Upload integration test results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           mkdir -p ${{ matrix.module }}/coverage/unit
           mkdir -p ${{ matrix.module }}/coverage/int
+          mkdir -p ${{ matrix.module }}/coverage/e2e
       # Run unit tests for the module.
       - name: go test
         working-directory: ${{ matrix.module }}
@@ -198,6 +199,25 @@ jobs:
           files: ${{ matrix.module }}/coverage.txt
           verbose: true
           fail_ci_if_error: true # optional (default = false)
+      - name: build e2e coverage
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        working-directory: ${{ matrix.module }}
+        run: |
+          if [ -d coverage/e2e ] && [ "$(ls -A coverage/e2e 2>/dev/null)" ]; then
+            echo "Converting e2e coverage to text format"
+            go tool covdata textfmt -i=./coverage/e2e -o coverage-e2e.txt
+          else
+            echo "No e2e coverage data found"
+          fi
+      - name: Upload e2e test coverage to Codecov
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.module }}/coverage-e2e.txt
+          flags: e2e
+          verbose: true
+          fail_ci_if_error: false
   release:
     #
     # Create a GitHub Release based on conventional commits.

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -147,7 +147,9 @@ jobs:
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
-        run: go-junit-report -in integration_test_output.txt -set-exit-code > junit_integration_report.xml || true
+        run: |
+          grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
+          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml || true
       - name: Integration Test Report
         uses: dorny/test-reporter@v1
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -170,15 +170,20 @@ jobs:
           name: junit-integration-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
-      - name: Extra Test Report
+      - name: Check extra JUnit report exists
+        id: check_extra_report
         if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        run: test -f "${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}"
+        continue-on-error: true
+      - name: Extra Test Report
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: codecov/test-results-action@v1
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+          INTEGRATION_COVERAGE=true go test -cover -covermode=atomic -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
             > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -27,6 +27,11 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      EXTRA_JUNIT_REPORT:
+        description: "Path to an additional JUnit XML report (e.g., from Python integration tests). Relative to the module directory."
+        type: string
+        required: false
+        default: ""
     secrets:
       GH_CI_PAT:
         description: 'Token password for GitHub auth'
@@ -156,6 +161,22 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
           files: ${{ matrix.module }}/junit_integration_report.xml
           name: junit-integration-report-${{ strategy.job-index }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # Extra JUnit report (e.g., from Python integration tests running inside Docker)
+      - name: Extra Test Report
+        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: dorny/test-reporter@v1
+        with:
+          name: Extra Test Report (${{ matrix.module }})
+          path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          reporter: java-junit
+      - name: Upload extra test results to Codecov
+        if: ${{ inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: codecov/test-results-action@v1
+        with:
+          fail_ci_if_error: false
+          files: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          name: junit-extra-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Coverage handling
       - name: build coverage.txt

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -225,6 +225,18 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
+      - name: Create Codecov commit
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: create-commit
+      - name: Send Codecov notifications
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications
   release:
     #
     # Create a GitHub Release based on conventional commits.

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -131,7 +131,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -162,7 +162,7 @@ jobs:
           reporter: java-junit
       - name: Upload integration test results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -200,7 +200,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage.txt
@@ -218,25 +218,13 @@ jobs:
           fi
       - name: Upload e2e test coverage to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage-e2e.txt
           flags: e2e
           verbose: true
           fail_ci_if_error: false
-      - name: Create Codecov commit
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: create-commit
-      - name: Send Codecov notifications
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: send-notifications
   release:
     #
     # Create a GitHub Release based on conventional commits.

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -220,15 +220,20 @@ jobs:
           name: junit-integration-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
-      - name: Extra Test Report
+      - name: Check extra JUnit report exists
+        id: check_extra_report
         if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        run: test -f "${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}"
+        continue-on-error: true
+      - name: Extra Test Report
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -30,6 +30,11 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      EXTRA_JUNIT_REPORT:
+        description: "Path to an additional JUnit XML report (e.g., from Python integration tests). Relative to the module directory."
+        type: string
+        required: false
+        default: ""
     secrets:
       GH_CI_PAT:
         description: "Token password for GitHub auth"
@@ -157,6 +162,7 @@ jobs:
         run: |
           mkdir -p ${{ matrix.module }}/coverage/unit
           mkdir -p ${{ matrix.module }}/coverage/int
+          mkdir -p ${{ matrix.module }}/coverage/e2e
       # Run unit tests for the module.
       - name: go test
         working-directory: ${{ matrix.module }}
@@ -187,12 +193,15 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
-            | tee integration_test_output.txt
+          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+            -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
+            > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
-        run: go-junit-report -in integration_test_output.txt -set-exit-code > junit_integration_report.xml || true
+        run: |
+          grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
+          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml || true
       - name: Integration Test Report
         uses: dorny/test-reporter@v1
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
@@ -200,6 +209,7 @@ jobs:
           name: Integration Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/junit_integration_report.xml
           reporter: java-junit
+          fail-on-error: 'false'
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/codecov-action@v5
@@ -208,6 +218,23 @@ jobs:
           report_type: test_results
           files: ${{ matrix.module }}/junit_integration_report.xml
           name: junit-integration-report-${{ strategy.job-index }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # Extra JUnit report (e.g., from Python integration tests running inside Docker)
+      - name: Extra Test Report
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: dorny/test-reporter@v1
+        with:
+          name: Extra Test Report (${{ matrix.module }})
+          path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          reporter: java-junit
+      - name: Upload extra test results to Codecov
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          report_type: test_results
+          files: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          name: junit-extra-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Coverage handling
       - name: build coverage.txt
@@ -226,3 +253,23 @@ jobs:
           files: ${{ matrix.module }}/coverage.txt
           verbose: true
           fail_ci_if_error: true # optional (default = false)
+      - name: build e2e coverage
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        working-directory: ${{ matrix.module }}
+        run: |
+          if [ -d coverage/e2e ] && [ "$(ls -A coverage/e2e 2>/dev/null)" ]; then
+            echo "Converting e2e coverage to text format"
+            go tool covdata textfmt -i=./coverage/e2e -o coverage-e2e.txt
+          else
+            echo "No e2e coverage data found"
+          fi
+      - name: Upload e2e test coverage to Codecov
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: coverage
+          files: ${{ matrix.module }}/coverage-e2e.txt
+          flags: e2e
+          verbose: true
+          fail_ci_if_error: false

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -193,7 +193,7 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+          INTEGRATION_COVERAGE=true go test -cover -covermode=atomic -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
             > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -181,7 +181,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -212,7 +212,7 @@ jobs:
           fail-on-error: 'false'
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -234,7 +234,7 @@ jobs:
           reporter: java-junit
       - name: Upload extra test results to Codecov
         if: ${{ steps.check_extra_report.outcome == 'success' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
           report_type: test_results
@@ -251,7 +251,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -270,7 +270,7 @@ jobs:
           fi
       - name: Upload e2e test coverage to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -278,15 +278,3 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
-      - name: Create Codecov commit
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: create-commit
-      - name: Send Codecov notifications
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: send-notifications

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -278,3 +278,15 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
+      - name: Create Codecov commit
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: create-commit
+      - name: Send Codecov notifications
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -148,7 +148,7 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+          INTEGRATION_COVERAGE=true go test -cover -covermode=atomic -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
             -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
             > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -31,6 +31,11 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      EXTRA_JUNIT_REPORT:
+        description: "Path to an additional JUnit XML report (e.g., from Python integration tests). Relative to the module directory."
+        type: string
+        required: false
+        default: ""
     secrets:
       GH_CI_PAT:
         description: 'Token password for GitHub auth'
@@ -112,6 +117,7 @@ jobs:
         run: |
           mkdir -p ${{ matrix.module }}/coverage/unit
           mkdir -p ${{ matrix.module }}/coverage/int
+          mkdir -p ${{ matrix.module }}/coverage/e2e
       # Run unit tests for the module.
       - name: go test
         working-directory: ${{ matrix.module }}
@@ -142,12 +148,15 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
-            | tee integration_test_output.txt
+          INTEGRATION_COVERAGE=true go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+            -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
+            > >(tee integration_test_output.txt) 2> >(tee integration_test_stderr.txt >&2)
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
-        run: go-junit-report -in integration_test_output.txt -set-exit-code > junit_integration_report.xml || true
+        run: |
+          grep -E '^(=== |--- |\s*(PASS|FAIL|ok\s|coverage:|SKIP|\?)\s)' integration_test_output.txt > integration_test_go_only.txt || true
+          go-junit-report -in integration_test_go_only.txt -set-exit-code > junit_integration_report.xml || true
       - name: Integration Test Report
         uses: dorny/test-reporter@v1
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
@@ -155,6 +164,7 @@ jobs:
           name: Integration Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/junit_integration_report.xml
           reporter: java-junit
+          fail-on-error: 'false'
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         uses: codecov/codecov-action@v5
@@ -163,6 +173,23 @@ jobs:
           report_type: test_results
           files: ${{ matrix.module }}/junit_integration_report.xml
           name: junit-integration-report-${{ strategy.job-index }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # Extra JUnit report (e.g., from Python integration tests running inside Docker)
+      - name: Extra Test Report
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: dorny/test-reporter@v1
+        with:
+          name: Extra Test Report (${{ matrix.module }})
+          path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          reporter: java-junit
+      - name: Upload extra test results to Codecov
+        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          report_type: test_results
+          files: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
+          name: junit-extra-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Coverage handling
       - name: build coverage.txt
@@ -181,6 +208,26 @@ jobs:
           files: ${{ matrix.module }}/coverage.txt
           verbose: true
           fail_ci_if_error: true # optional (default = false)
+      - name: build e2e coverage
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
+        working-directory: ${{ matrix.module }}
+        run: |
+          if [ -d coverage/e2e ] && [ "$(ls -A coverage/e2e 2>/dev/null)" ]; then
+            echo "Converting e2e coverage to text format"
+            go tool covdata textfmt -i=./coverage/e2e -o coverage-e2e.txt
+          else
+            echo "No e2e coverage data found"
+          fi
+      - name: Upload e2e test coverage to Codecov
+        if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: coverage
+          files: ${{ matrix.module }}/coverage-e2e.txt
+          flags: e2e
+          verbose: true
+          fail_ci_if_error: false
   release:
     #
     # Create a GitHub Release based on conventional commits.

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -175,15 +175,20 @@ jobs:
           name: junit-integration-report-${{ strategy.job-index }}
           token: ${{ secrets.CODECOV_TOKEN }}
       # Extra JUnit report (e.g., from Python integration tests running inside Docker)
-      - name: Extra Test Report
+      - name: Check extra JUnit report exists
+        id: check_extra_report
         if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        run: test -f "${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}"
+        continue-on-error: true
+      - name: Extra Test Report
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: dorny/test-reporter@v1
         with:
           name: Extra Test Report (${{ matrix.module }})
           path: ${{ matrix.module }}/${{ inputs.EXTRA_JUNIT_REPORT }}
           reporter: java-junit
       - name: Upload extra test results to Codecov
-        if: ${{ (success() || failure()) && inputs.EXTRA_JUNIT_REPORT != '' && inputs.GO_TEST_INTEGRATION_ENABLED }}
+        if: ${{ steps.check_extra_report.outcome == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -233,6 +233,18 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
+      - name: Create Codecov commit
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: create-commit
+      - name: Send Codecov notifications
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications
   release:
     #
     # Create a GitHub Release based on conventional commits.

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -136,7 +136,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -167,7 +167,7 @@ jobs:
           fail-on-error: 'false'
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -189,7 +189,7 @@ jobs:
           reporter: java-junit
       - name: Upload extra test results to Codecov
         if: ${{ steps.check_extra_report.outcome == 'success' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
           report_type: test_results
@@ -206,7 +206,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -225,7 +225,7 @@ jobs:
           fi
       - name: Upload e2e test coverage to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED && hashFiles(format('{0}/coverage-e2e.txt', matrix.module)) != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -233,18 +233,6 @@ jobs:
           flags: e2e
           verbose: true
           fail_ci_if_error: false
-      - name: Create Codecov commit
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: create-commit
-      - name: Send Codecov notifications
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          run_command: send-notifications
   release:
     #
     # Create a GitHub Release based on conventional commits.


### PR DESCRIPTION
 Changes applied to all 4 Go workflows (app + lib, pull_requests + push_main):

  1. EXTRA_JUNIT_REPORT input parameter
  Allows caller workflows to specify a path to an additional JUnit XML report file (e.g., from Python integration tests running inside Docker containers). Optional, defaults to empty string — no impact on existing
  workflows that don't use it.

  2. coverage/e2e directory
  Added to the coverage output directories step. Separates coverage from application binaries running inside Docker (hit by external tests like Python) from Go integration test coverage (coverage/int) and unit test
   coverage (coverage/unit). Codecov merges all uploads automatically.

  3. Stdout/stderr separation for integration tests
  Changed 2>&1 | tee to > >(tee ...) 2> >(tee ... >&2). Go's log.Println (used by testcontainers-go) writes to stderr, but 2>&1 mixed it into stdout. This caused go-junit-report to parse Python test output lines
  (like ok (0.003s)) as Go test cases, producing ghost entries in the Integration Test Report. Separating streams keeps only Go test output in integration_test_output.txt.

  4. Grep filter before go-junit-report
  Filters integration_test_output.txt to only keep lines matching Go test framework patterns (=== RUN, --- PASS, PASS, FAIL, ok, coverage:, etc.) before passing to go-junit-report. This is a second line of defense
  against non-Go output leaking into the JUnit report, since go test -v re-emits all test binary output through its own stdout regardless of stderr separation.

  5. fail-on-error: 'false' on Integration Test Report
  The dorny/test-reporter action defaults to failing the job when it detects test failures in the JUnit XML. With mixed Go/Python output, go-junit-report could produce false failures that would block the entire CI
  pipeline. Setting this to false is safe because the go test step itself already fails the job via exit code if tests actually fail. The reporter is purely for display purposes.

  6. Extra Test Report steps
  Two new steps that run when EXTRA_JUNIT_REPORT is set: dorny/test-reporter (displays results as a GitHub check with individual test names) and codecov-action@v5 (uploads results to Codecov test analytics). Both
  use success() || failure() condition so they run even if the Integration Test Report step fails.

  7. E2e coverage build + upload steps
  Converts coverage data from coverage/e2e/ (collected from Docker containers built with -cover) to text format and uploads to Codecov with the e2e flag. This keeps e2e coverage separate from the combined
  unit+integration coverage upload, giving visibility into how much code is exercised by external tests vs. Go tests.

  8. Coverage flags and integration test coverage collection (push_main)
  Added INTEGRATION_COVERAGE=true, -cover, and -test.gocoverdir flags to integration test runs that were missing them. This ensures integration test coverage is collected on push-to-main, not just on pull requests.