### PR TITLE
chore: bump codecov to v7

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -172,7 +172,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -199,7 +199,7 @@ jobs:
           reporter: java-junit
       - name: Upload integration test results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -216,7 +216,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -125,7 +125,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -152,7 +152,7 @@ jobs:
           reporter: java-junit
       - name: Upload integration test results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -169,7 +169,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/coverage.txt

--- a/.github/workflows/go_lib_pull_requests.yml
+++ b/.github/workflows/go_lib_pull_requests.yml
@@ -175,7 +175,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -202,7 +202,7 @@ jobs:
           reporter: java-junit
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -219,7 +219,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage

--- a/.github/workflows/go_lib_push_main.yml
+++ b/.github/workflows/go_lib_push_main.yml
@@ -130,7 +130,7 @@ jobs:
           path: ${{ matrix.module }}/junit_report.xml
           reporter: java-junit
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -157,7 +157,7 @@ jobs:
           reporter: java-junit
       - name: Upload integration test coverage results to Codecov
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # optional (default = false)
           report_type: test_results
@@ -174,7 +174,7 @@ jobs:
             go tool covdata textfmt -i=./coverage/unit -o coverage.txt
           fi
       - name: Upload test coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage

--- a/.github/workflows/php_lib_pull_requests.yml
+++ b/.github/workflows/php_lib_pull_requests.yml
@@ -108,7 +108,7 @@ jobs:
         run: ${{ inputs.COMPOSER_WORKING_DIRECTORY }}/vendor/bin/phpunit --log-junit junit.xml --coverage-clover coverage.xml --testsuite ${{ inputs.PHP_UNIT_TESTSUITE }}
       - name: Upload test coverage results to Codecov
         if: ${{ inputs.PHP_UNIT }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov

--- a/.github/workflows/php_lib_push_main.yml
+++ b/.github/workflows/php_lib_push_main.yml
@@ -90,7 +90,7 @@ jobs:
         run: ${{ inputs.COMPOSER_WORKING_DIRECTORY }}/vendor/bin/phpunit --log-junit junit.xml --coverage-clover coverage.xml --testsuite ${{ inputs.PHP_UNIT_TESTSUITE }}
       - name: Upload test coverage results to Codecov
         if: ${{ inputs.PHP_UNIT }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov


### PR DESCRIPTION
Fixes the GPG key verification issue caused by Codecov's recent migration https://github.com/codecov/codecov-action/issues/1956