### PR TITLE
fix(go/app): capture integration test coverage so it counts in Codecov

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -184,8 +184,9 @@ jobs:
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}
         run: |
-          go test -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
-            | tee integration_test_output.txt
+          go test -cover -v ${{ inputs.GO_TEST_INTEGRATION_TAGS }} -timeout ${{ inputs.GO_TEST_INTEGRATION_TIMEOUT }} ./... \
+            -args -test.gocoverdir="${{ github.workspace }}/${{ matrix.module }}/coverage/int" \
+            2>&1 | tee integration_test_output.txt
       - name: Build Integration Test Junit report
         if: ${{ inputs.GO_TEST_INTEGRATION_ENABLED }}
         working-directory: ${{ matrix.module }}


### PR DESCRIPTION
## Problem
The `go_app_pull_requests.yml` integration-test step runs `go test` with **no `-cover` / `-test.gocoverdir`**, so it emits no coverage. The `build coverage.txt` merge step then finds `coverage/int` empty and falls back to **unit-only** coverage. Any code covered **only** by integration (testcontainers) tests — DAOs, DI wiring — always reports uncovered and fails `codecov/patch`. Surfaced on Kochava/event-measurement-ingestion#160 (a rollup DAO change that's fully integration-tested but shows 0% patch).

## Fix
Instrument the integration step exactly like the unit step — `-cover` + `-test.gocoverdir` into `coverage/int` (already `mkdir -p`'d) — so the existing merge folds it into the uploaded profile.

## Safety
Strictly **additive**: adding integration coverage can only mark more lines covered → consumers' patch/project coverage can only rise or stay, never regress. No change when `GO_TEST_INTEGRATION_ENABLED` is off.

## Rollout note
Consumers pin the `go/app/v2` **tag**, so after merge the `go/app/v2` tag needs to be re-cut onto this commit (or consumers repoint) for it to take effect.