### PR TITLE
feat: add opt-in Go coverage profile artifact

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -26,6 +26,10 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      COVERAGE_ARTIFACT_ENABLED:
+        description: "Publish the Go coverage profile as an artifact named go-coverage so the caller can upload it to GitHub code coverage"
+        type: boolean
+        default: false
     secrets:
       GH_CI_PAT:
         description: 'Token password for GitHub auth'
@@ -223,6 +227,13 @@ jobs:
           files: ${{ matrix.module }}/coverage.txt
           verbose: true
           fail_ci_if_error: true # optional (default = false)
+      - name: Upload coverage profile artifact
+        if: ${{ inputs.COVERAGE_ARTIFACT_ENABLED }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage
+          path: ${{ matrix.module }}/coverage.txt
+          if-no-files-found: error
   docker-build:
     #
     # ensures the docker image will build without pushing to the registry

--- a/.github/workflows/go_app_push_main.yml
+++ b/.github/workflows/go_app_push_main.yml
@@ -27,6 +27,10 @@ on:
         description: "The duration before tests are stopped"
         type: string
         default: "10m"
+      COVERAGE_ARTIFACT_ENABLED:
+        description: "Publish the Go coverage profile as an artifact named go-coverage so the caller can upload it to GitHub code coverage"
+        type: boolean
+        default: false
     secrets:
       GH_CI_PAT:
         description: 'Token password for GitHub auth'
@@ -175,6 +179,13 @@ jobs:
           files: ${{ matrix.module }}/coverage.txt
           verbose: true
           fail_ci_if_error: true # optional (default = false)
+      - name: Upload coverage profile artifact
+        if: ${{ inputs.COVERAGE_ARTIFACT_ENABLED }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage
+          path: ${{ matrix.module }}/coverage.txt
+          if-no-files-found: error
   release:
     #
     # Create a GitHub Release based on conventional commits.


### PR DESCRIPTION
Publish the coverage profile the Go app workflows already build as an artifact named go-coverage, so a caller can convert it to Cobertura XML and upload it to GitHub code coverage.

Gated behind COVERAGE_ARTIFACT_ENABLED, default false, so no existing caller changes behavior.